### PR TITLE
separate solver! and update_pad!

### DIFF
--- a/src/iterations/iterations.jl
+++ b/src/iterations/iterations.jl
@@ -125,6 +125,9 @@ function iter!(pt :: Point{T}, itd :: IterData{T}, fd :: Abstract_QM_FloatData{T
     
     @inbounds while cnts.k < sc.max_iter && !sc.optimal && !sc.tired # && !small_μ && !small_μ
 
+        out = update_pad!(pad, dda, pt, itd, fd, id, res, cnts, T0) # update data for the solver! function used
+        out == 1 && break
+
         # Solve system to find a direction of descent 
         out = update_dd!(dda, pt, itd, fd, id, res, pad, cnts, T0)
         out == 1 && break
@@ -136,7 +139,7 @@ function iter!(pt :: Point{T}, itd :: IterData{T}, fd :: Abstract_QM_FloatData{T
             ## TODO replace by centrality_corr.jl, deal with α
         end
 
-        update_data!(pt, α_pri, α_dual, itd, pad, res, fd, id)
+        update_data!(pt, α_pri, α_dual, itd, pad, res, fd, id) # update point, residuals, objectives...
 
         sc.optimal = itd.pdd < ϵ.pdd && res.rbNorm < ϵ.tol_rb && res.rcNorm < ϵ.tol_rc
         sc.small_Δx, sc.small_μ = res.n_Δx < ϵ.Δx, itd.μ < ϵ.μ

--- a/src/iterations/regularization.jl
+++ b/src/iterations/regularization.jl
@@ -39,7 +39,7 @@ function update_regu!(regu)
 end
 
 # update regularization, and corrects if the magnitude of the diagonal of the matrix is too high
-function update_regu_diagJ!(regu, K_nzval, diagind_K, nvar, pdd, l_pdd, mean_pdd, cnts, T, T0)
+function update_regu_diagK2!(regu, K_nzval, diagind_K, nvar, pdd, l_pdd, mean_pdd, cnts, T, T0)
 
     l_pdd[cnts.k%6+1] = pdd
     mean_pdd = mean(l_pdd)
@@ -69,7 +69,7 @@ function update_regu_diagJ!(regu, K_nzval, diagind_K, nvar, pdd, l_pdd, mean_pdd
     return 0
 end
 
-function update_regu_diagJ_K2_5!(regu, D, pdd, l_pdd, mean_pdd, cnts, T, T0)
+function update_regu_diagK2_5!(regu, D, pdd, l_pdd, mean_pdd, cnts, T, T0)
 
     l_pdd[cnts.k%6+1] = pdd
     mean_pdd = mean(l_pdd)

--- a/src/refinement.jl
+++ b/src/refinement.jl
@@ -34,6 +34,7 @@ function fd_refinement(fd :: QM_FloatData{T}, id :: QM_IntData, res :: Residuals
         itd.Δxy[id.ilow] .-= itd.μ  ./ itd.x_m_lvar
         itd.Δxy[id.iupp] .+= itd.μ ./ itd.uvar_m_x
         if pad.fact_fail
+            out = update_pad!(pad, dda, pt, itd, fd, id, res, cnts, T0)
             out = solver!(pad, dda, pt, itd, fd, id, res, cnts, T0, :IPF)
         else
             out = solver!(pad, dda, pt, itd, fd, id, res, cnts, T0, :cc)


### PR DESCRIPTION
The factorization and update of K is now separated from the computation of the descent direction to avoid updating several times when using centrality corrections