### PR TITLE
use push_preview = true in deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,4 +26,5 @@ deploydocs(
   repo = "github.com/JuliaSmoothOptimizers/RipQP.jl.git",
   target = "build",
   devbranch = "main",
+  push_preview = true,
 )


### PR DESCRIPTION
With this change, a new workflow named "documenter/deploy" appears in the list of checks when the docs have finished building.
Clicking on "details" takes you to the docs resulting from the pull request.